### PR TITLE
make .event case insensitive

### DIFF
--- a/src/Cogs/ump.py
+++ b/src/Cogs/ump.py
@@ -116,7 +116,11 @@ class Ump(commands.Cog):
             sheet_id = config[2]
             valid_events = ['Swing', 'Auto K', 'Auto BB', 'Bunt', 'Steal 2B', 'Steal 3B', 'Steal Home', 'Infield In',
                             'IBB']
-            if event_type not in valid_events:
+            # Kinda hacky, but this will match a case whatever input to a properly cased version for the sheet.
+            try:
+                event_type = next(event for event in valid_events if event_type.lower() == event.lower())
+            except StopIteration:
+                # next() raises a StopIteration error, so we can just put the previous code into here.
                 await ctx.send('%s is not a valid event type. Please use: %s' % (event_type, valid_events))
             else:
                 if event_type in ['Auto K', 'Auto BB', 'IBB']:


### PR DESCRIPTION
uses the next() function and a generator, so avoids having to create a dict object or anything of that nature. i havent been able to test this with the actual sheet and stuff, since i havent set those up, but i tested using an equivalent bot (see attachments for source code and results).
![image](https://user-images.githubusercontent.com/27144780/134778844-285aaaf8-25c8-4631-bfc7-bad3e114a2c6.png)
![image](https://user-images.githubusercontent.com/27144780/134778854-63386727-89d5-4f6b-93dd-73ccad589763.png)
